### PR TITLE
Fix a PHP notice

### DIFF
--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -463,7 +463,7 @@ class Query {
         array_merge(
             trim($queryWithFilters) === '' ? array( $this->indexName ) : array( $this->indexName, $queryWithFilters ),
             explode( ' ', $this->limit ),
-            explode( ' ', $this->slop ),
+            explode( ' ', $this->slop ?? '' ),
             array( $this->verbatim, $this->withScores, $this->withSortKey, $this->withPayloads, $this->noStopWords, $this->noContent),
             explode( ' ', $this->inFields),
             explode( ' ', $this->inKeys ),


### PR DESCRIPTION
On PHP >= 8.1 this error might pop up

```
Deprecated function: explode(): Passing null to parameter #2 ($string) of type string is deprecated in FKRediSearch\Query\Query->searchQueryArgs() (line 466 of /var/www/html/vendor/front/redisearch/src/Query/Query.php)
```

Luckily there is an easy fix, which is included in this here PR